### PR TITLE
Remove need for double query in template tags

### DIFF
--- a/molo/commenting/models.py
+++ b/molo/commenting/models.py
@@ -18,4 +18,4 @@ class MoloComment(MPTTModel, Comment):
 
     class Meta:
         app_label = 'commenting'
-        ordering = ['tree_id', 'lft']
+        ordering = ['-submit_date', 'tree_id', 'lft']

--- a/molo/commenting/templatetags/molo_commenting_tags.py
+++ b/molo/commenting/templatetags/molo_commenting_tags.py
@@ -53,12 +53,10 @@ class GetMoloCommentsNode(template.Node):
             return ''
 
         qs = MoloComment.objects.for_model(obj.__class__).filter(
-            object_pk=obj.pk)
-        qs = qs.order_by("-submit_date")
+            object_pk=obj.pk, parent__isnull=True)
         if self.limit > 0:
             qs = qs[:self.limit]
-        context[self.variable_name] = MoloComment.objects.filter(
-            pk__in=map(lambda r: r.pk, qs))
+        context[self.variable_name] = qs
         return ''
 
 


### PR DESCRIPTION
https://github.com/praekelt/molo.commenting/pull/5 introduces a second queryset to limit the amount of comments returned. Chances are this can be done better somehow.
