### PR TITLE
Make comment admin more moderation friendly

### DIFF
--- a/molo/commenting/admin.py
+++ b/molo/commenting/admin.py
@@ -7,7 +7,14 @@ from django_comments.admin import CommentsAdmin
 
 
 class MoloCommentAdmin(CommentsAdmin):
-    list_display = ('comment', 'content_object', 'user', 'is_removed', 'submit_date')
+    list_display = ('comment', 'content_object', 'user', 'is_removed', 'is_reported', 'submit_date')
+    
+    def is_reported(self, obj):
+        if (obj.flags.count()>0):
+            return True
+        return False
+    is_reported.admin_order_field = 'is_reported'
+    is_reported.boolean = True
     
 
 admin.site.register(MoloComment, MoloCommentAdmin)

--- a/molo/commenting/admin.py
+++ b/molo/commenting/admin.py
@@ -1,10 +1,14 @@
 from django.contrib import admin
 
 from molo.commenting.models import MoloComment
+from molo.core.models import ArticlePage
 from django_comments.models import CommentFlag
 from django_comments.admin import CommentsAdmin
 from django.core.urlresolvers import reverse
+from django.core.exceptions import PermissionDenied
 from django.contrib.admin.views.main import ChangeList
+from django.shortcuts import get_object_or_404
+from django.contrib.admin.utils import unquote
 from django.contrib.contenttypes.models import ContentType
 
 
@@ -85,5 +89,79 @@ class MoloCommentAdmin(CommentsAdmin):
 
         return ModeratorChangeList
 
+
+class AdminModeratorMixin(admin.ModelAdmin):
+    def change_view(self, request, object_id, form_url='', extra_context=None):
+        """
+        Override change view to add extra context enabling moderate tool.
+        """
+        context = {
+            'has_moderate_tool': True
+        }
+        if extra_context:
+            context.update(extra_context)
+        return super(AdminModeratorMixin, self).change_view(
+            request=request,
+            object_id=object_id,
+            form_url=form_url,
+            extra_context=context
+        )
+
+    def get_urls(self):
+        """
+        Add aditional moderate url.
+        """
+        from django.conf.urls import patterns, url
+        urls = super(AdminModeratorMixin, self).get_urls()
+        info = self.model._meta.app_label, self.model._meta.model_name
+        return patterns(
+            '',
+            url(r'^(.+)/moderate/$',
+                self.admin_site.admin_view(self.moderate_view),
+                name='%s_%s_moderate' % info),
+        ) + urls
+
+    def moderate_view(self, request, object_id, extra_context=None):
+        """
+        Handles moderate object tool through a somewhat hacky changelist view
+        whose queryset is altered via MoloCommentAdmin.get_changelist to only
+        list comments for the object under review.
+        """
+        opts = self.model._meta
+        app_label = opts.app_label
+
+        view = MoloCommentAdmin(model=MoloComment, admin_site=self.admin_site)
+
+        view.list_filter = ()
+        view.list_display = (
+            'comment',
+            'content_object',
+            '_user',
+            'submit_date',
+        )
+
+        model = self.model
+        obj = get_object_or_404(model, pk=unquote(object_id))
+        request.obj = obj
+        view.change_list_template = self.change_list_template or [
+            'admin/%s/%s/moderate.html' % (app_label, opts.object_name.lower()),
+            'admin/%s/moderate.html' % app_label,
+            'admin/moderate.html'
+        ]
+        orig_has_change_permission = self.has_change_permission(request, obj)
+        if not orig_has_change_permission:
+            raise PermissionDenied
+        extra_context = {
+            'opts': opts,
+            'original': obj,
+            'orig_has_change_permission': orig_has_change_permission,
+        }
+        return view.changelist_view(request, extra_context)
+
+
+class ModeratedPageAdmin(AdminModeratorMixin, admin.ModelAdmin):
+    pass
+
 admin.site.register(MoloComment, MoloCommentAdmin)
 admin.site.register(CommentFlag)
+admin.site.register(ArticlePage, ModeratedPageAdmin)

--- a/molo/commenting/admin.py
+++ b/molo/commenting/admin.py
@@ -17,11 +17,16 @@ class MoloCommentAdmin(CommentsAdmin):
     is_reported.admin_order_field = 'is_reported'
     is_reported.boolean = True
     
+    def get_user_display_name(self, obj):
+        if obj.name.lower().startswith('anon'):
+            return obj.user.username
+        return obj.name
+    
     def _user(self, obj):
         url = reverse('admin:auth_user_change', args=(obj.user.id,))
         return '<a href="?user=%s">%s</a>' % (
             obj.user.id,
-            obj.user
+            self.get_user_display_name(obj)
         ) + ' (<a href="%s">edit</a>)' % url
     _user.allow_tags = True
     _user.short_description = 'User'

--- a/molo/commenting/admin.py
+++ b/molo/commenting/admin.py
@@ -4,6 +4,8 @@ from molo.commenting.models import MoloComment
 from django_comments.models import CommentFlag
 from django_comments.admin import CommentsAdmin
 from django.core.urlresolvers import reverse
+from django.contrib.admin.views.main import ChangeList
+from django.contrib.contenttypes.models import ContentType
 
 
 class MoloCommentAdmin(CommentsAdmin):
@@ -37,6 +39,51 @@ class MoloCommentAdmin(CommentsAdmin):
         )
     content.allow_tags = True
     content.short_description = 'Content'
-    
+
+    def get_changelist(self, request):
+        class ModeratorChangeList(ChangeList):
+            def get_queryset(self, request):
+                """
+                Used by AdminModeratorMixin.moderate_view to somewhat hackishly
+                limit comments to only those for the object under review, but
+                only if an obj attribute is found on request (which means the
+                mixin is being applied and we are not on the standard
+                changelist_view).
+                """
+                qs = super(ModeratorChangeList, self).get_queryset(request)
+                obj = getattr(request, 'obj', None)
+                if obj:
+                    ct = ContentType.objects.get_for_model(obj)
+                    qs = qs.filter(content_type=ct, object_pk=obj.pk)
+                return qs
+
+            def get_results(self, request):
+                """
+                Create a content_type map to individual objects through their
+                id's to avoid additional per object queries for generic
+                relation lookup (used in MoloCommentAdmin.content method).
+                Also create a comment_reply map to avoid additional reply
+                lookups per comment object
+                (used in CommentAdmin.moderator_reply method)
+                """
+                super(ModeratorChangeList, self).get_results(request)
+                comment_ids = []
+                object_pks = []
+
+                results = list(self.result_list)
+                for obj in results:
+                    comment_ids.append(obj.id)
+                    object_pks.append(obj.object_pk)
+
+                ct_map = {}
+                for obj in results:
+                    if obj.content_type not in ct_map:
+                        ct_map.setdefault(obj.content_type, {})
+                        for content_obj in obj.content_type.model_class()._default_manager.filter(pk__in=object_pks):
+                            ct_map[obj.content_type][content_obj.id] = content_obj
+                self.model_admin.ct_map = ct_map
+
+        return ModeratorChangeList
+
 admin.site.register(MoloComment, MoloCommentAdmin)
 admin.site.register(CommentFlag)

--- a/molo/commenting/admin.py
+++ b/molo/commenting/admin.py
@@ -18,7 +18,7 @@ class MoloCommentAdmin(CommentsAdmin):
         'submit_date')
 
     def is_reported(self, obj):
-        if (obj.flags.count() > 0):
+        if (obj.flag_count(CommentFlag.SUGGEST_REMOVAL) > 0):
             return True
         return False
     is_reported.admin_order_field = 'is_reported'

--- a/molo/commenting/admin.py
+++ b/molo/commenting/admin.py
@@ -13,20 +13,22 @@ from django.contrib.contenttypes.models import ContentType
 
 
 class MoloCommentAdmin(CommentsAdmin):
-    list_display = ('comment', 'content', '_user', 'is_removed', 'is_reported', 'submit_date')
-    
+    list_display = (
+        'comment', 'content', '_user', 'is_removed', 'is_reported',
+        'submit_date')
+
     def is_reported(self, obj):
-        if (obj.flags.count()>0):
+        if (obj.flags.count() > 0):
             return True
         return False
     is_reported.admin_order_field = 'is_reported'
     is_reported.boolean = True
-    
+
     def get_user_display_name(self, obj):
         if obj.name.lower().startswith('anon'):
             return obj.user.username
         return obj.name
-    
+
     def _user(self, obj):
         url = reverse('admin:auth_user_change', args=(obj.user.id,))
         return '<a href="?user=%s">%s</a>' % (
@@ -91,8 +93,10 @@ class MoloCommentAdmin(CommentsAdmin):
                 for obj in results:
                     if obj.content_type not in ct_map:
                         ct_map.setdefault(obj.content_type, {})
-                        for content_obj in obj.content_type.model_class()._default_manager.filter(pk__in=object_pks):
-                            ct_map[obj.content_type][content_obj.id] = content_obj
+                        for content_obj in obj.content_type.model_class()\
+                                ._default_manager.filter(pk__in=object_pks):
+                            ct_map[
+                                obj.content_type][content_obj.id] = content_obj
                 self.model_admin.ct_map = ct_map
 
         return ModeratorChangeList
@@ -152,7 +156,8 @@ class AdminModeratorMixin(admin.ModelAdmin):
         obj = get_object_or_404(model, pk=unquote(object_id))
         request.obj = obj
         view.change_list_template = self.change_list_template or [
-            'admin/%s/%s/moderate.html' % (app_label, opts.object_name.lower()),
+            'admin/%s/%s/moderate.html' % (
+                app_label, opts.object_name.lower()),
             'admin/%s/moderate.html' % app_label,
             'admin/moderate.html'
         ]

--- a/molo/commenting/admin.py
+++ b/molo/commenting/admin.py
@@ -35,12 +35,20 @@ class MoloCommentAdmin(CommentsAdmin):
         ) + ' (<a href="%s">edit</a>)' % url
     _user.allow_tags = True
     _user.short_description = 'User'
-    
-    def content(self, obj):
-        return '<a href="?object_pk=%s">%s</a>' % (
-            obj.object_pk,
-            obj.content_object
-        )
+
+    def content(self, obj, *args, **kwargs):
+        content_type = obj.content_type
+        if not int(obj.object_pk) in self.ct_map[content_type]:
+            content = obj
+        else:
+            content = self.ct_map[content_type][int(obj.object_pk)]
+        url = reverse('admin:%s_%s_moderate' % (
+            content_type.app_label,
+            content_type.model
+        ), args=(content.id,))
+
+        return '<a href="%s">%s</a>' % (url, content)
+
     content.allow_tags = True
     content.short_description = 'Content'
 

--- a/molo/commenting/admin.py
+++ b/molo/commenting/admin.py
@@ -6,9 +6,8 @@ from django_comments.admin import CommentsAdmin
 from django.core.urlresolvers import reverse
 
 
-
 class MoloCommentAdmin(CommentsAdmin):
-    list_display = ('comment', 'content_object', '_user', 'is_removed', 'is_reported', 'submit_date')
+    list_display = ('comment', 'content', '_user', 'is_removed', 'is_reported', 'submit_date')
     
     def is_reported(self, obj):
         if (obj.flags.count()>0):
@@ -30,7 +29,14 @@ class MoloCommentAdmin(CommentsAdmin):
         ) + ' (<a href="%s">edit</a>)' % url
     _user.allow_tags = True
     _user.short_description = 'User'
-
-
+    
+    def content(self, obj):
+        return '<a href="?object_pk=%s">%s</a>' % (
+            obj.object_pk,
+            obj.content_object
+        )
+    content.allow_tags = True
+    content.short_description = 'Content'
+    
 admin.site.register(MoloComment, MoloCommentAdmin)
 admin.site.register(CommentFlag)

--- a/molo/commenting/admin.py
+++ b/molo/commenting/admin.py
@@ -2,7 +2,13 @@ from django.contrib import admin
 
 from molo.commenting.models import MoloComment
 from django_comments.models import CommentFlag
+from django_comments.admin import CommentsAdmin
 
 
-admin.site.register(MoloComment)
+
+class MoloCommentAdmin(CommentsAdmin):
+    list_display = ('comment', 'content_object', 'user', 'is_removed', 'submit_date')
+    
+
+admin.site.register(MoloComment, MoloCommentAdmin)
 admin.site.register(CommentFlag)

--- a/molo/commenting/admin.py
+++ b/molo/commenting/admin.py
@@ -3,11 +3,12 @@ from django.contrib import admin
 from molo.commenting.models import MoloComment
 from django_comments.models import CommentFlag
 from django_comments.admin import CommentsAdmin
+from django.core.urlresolvers import reverse
 
 
 
 class MoloCommentAdmin(CommentsAdmin):
-    list_display = ('comment', 'content_object', 'user', 'is_removed', 'is_reported', 'submit_date')
+    list_display = ('comment', 'content_object', '_user', 'is_removed', 'is_reported', 'submit_date')
     
     def is_reported(self, obj):
         if (obj.flags.count()>0):
@@ -16,6 +17,15 @@ class MoloCommentAdmin(CommentsAdmin):
     is_reported.admin_order_field = 'is_reported'
     is_reported.boolean = True
     
+    def _user(self, obj):
+        url = reverse('admin:auth_user_change', args=(obj.user.id,))
+        return '<a href="?user=%s">%s</a>' % (
+            obj.user.id,
+            obj.user
+        ) + ' (<a href="%s">edit</a>)' % url
+    _user.allow_tags = True
+    _user.short_description = 'User'
+
 
 admin.site.register(MoloComment, MoloCommentAdmin)
 admin.site.register(CommentFlag)

--- a/molo/commenting/models.py
+++ b/molo/commenting/models.py
@@ -27,6 +27,7 @@ class MoloComment(MPTTModel, Comment):
     def flag_count(self, flag):
         return self.flags.filter(flag=flag).count()
 
+
 @receiver(comment_was_flagged, sender=MoloComment)
 def remove_comment_if_flag_limit(sender, comment, flag, created, **kwargs):
     # Auto removal is off by default

--- a/molo/commenting/models.py
+++ b/molo/commenting/models.py
@@ -24,6 +24,8 @@ class MoloComment(MPTTModel, Comment):
         app_label = 'commenting'
         ordering = ['-submit_date', 'tree_id', 'lft']
 
+    def flag_count(self, flag):
+        return self.flags.filter(flag=flag).count()
 
 @receiver(comment_was_flagged, sender=MoloComment)
 def remove_comment_if_flag_limit(sender, comment, flag, created, **kwargs):
@@ -36,9 +38,9 @@ def remove_comment_if_flag_limit(sender, comment, flag, created, **kwargs):
     if flag.flag != CommentFlag.SUGGEST_REMOVAL:
         return
     # Don't remove comments that have been approved by a moderator
-    if (comment.flags.filter(flag=CommentFlag.MODERATOR_APPROVAL).count() > 0):
+    if (comment.flag_count(CommentFlag.MODERATOR_APPROVAL) > 0):
         return
 
-    if (comment.flags.count() >= threshold_count):
+    if (comment.flag_count(CommentFlag.SUGGEST_REMOVAL) >= threshold_count):
         comment.is_removed = True
         comment.save()

--- a/molo/commenting/templates/admin/moderate.html
+++ b/molo/commenting/templates/admin/moderate.html
@@ -1,0 +1,28 @@
+{% extends "admin/change_list.html" %}
+{% load i18n admin_urls %}
+{% load url from future %}
+
+{% block extrahead %}
+{{ block.super }}
+    <script type="text/javascript">
+        function dismissAddAnotherPopup(win, newId, newRepr) {
+            // Override of builtin dismissAddAnotherPopup to
+            // display comment reply text.
+            var repl_id = windowname_to_id(win.name);
+            repl_element = django.jQuery("#" + repl_id).parent();
+            repl_element.html(newRepr.split(": ")[1]);
+            win.close();
+        }
+    </script>
+{% endblock %}
+
+{% if not is_popup %}
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+<a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+&rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_label|capfirst|escape }}</a>
+&rsaquo; {% if orig_has_change_permission %}<a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>{% else %}{{ opts.verbose_name_plural|capfirst }}{% endif %}
+&rsaquo; {% trans 'Moderate' %} {{ original|truncatewords:"18" }}
+</div>
+{% endblock %}
+{% endif %}


### PR DESCRIPTION
through the admin users should be able to:
- list all comments
- list all visible comments
- list all removed comments
- list all comments made by a user
- list all comments made on an article
