### PR TITLE
Tidy in preparation for Django upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ install:
   - pip install twine
   - pip install --upgrade pip --cache-dir $HOME/.pip-cache/
   - pip install coveralls coverage --cache-dir $HOME/.pip-cache/
-  - pip install flake8 --cache-dir $HOME/.pip-cache/
   - pip install -r requirements-dev.txt --cache-dir $HOME/.pip-cache/
   - pip install -e . --cache-dir $HOME/.pip-cache/
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache:
   directories:
     - $HOME/.pip-cache/
 install:
-  - pip install twine
   - pip install --upgrade pip --cache-dir $HOME/.pip-cache/
   - pip install coveralls coverage --cache-dir $HOME/.pip-cache/
   - pip install -r requirements-dev.txt --cache-dir $HOME/.pip-cache/
@@ -23,6 +22,8 @@ script:
   - py.test --cov=molo
 after_success:
   - coveralls
+before_deploy:
+  - pip install twine
 deploy:
   provider: pypi
   user: Praekelt

--- a/README.rst
+++ b/README.rst
@@ -28,10 +28,10 @@ Django setup::
 
 In your urls.py::
 
-   urlpatterns += patterns('',
+   urlpatterns += [,
        url(r'^commenting/',include('molo.commenting.urls', namespace='molo.commenting', app_name='molo.commenting')),
        url(r'', include('django_comments.urls')),
-   )
+   ]
 
 In your article_page.html::
 

--- a/molo/commenting/admin.py
+++ b/molo/commenting/admin.py
@@ -6,7 +6,7 @@ from django.contrib import admin
 from django.contrib.admin.templatetags.admin_static import static
 from django.core.urlresolvers import reverse
 from django.core.exceptions import PermissionDenied
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.contrib.admin.views.main import ChangeList
 from django.shortcuts import get_object_or_404
 from django.contrib.admin.utils import unquote
@@ -36,13 +36,12 @@ class MoloCommentAdmin(MPTTModelAdmin, CommentsAdmin):
 
     def get_urls(self):
         urls = super(MoloCommentAdmin, self).get_urls()
-        my_urls = patterns(
-            '',
+        my_urls = [
             url(
                 r'(?P<parent>\d+)/reply/$',
                 self.admin_site.admin_view(AdminCommentReplyView.as_view()),
                 name="commenting_molocomment_reply")
-        )
+        ]
         return my_urls + urls
 
     def is_reported(self, obj):
@@ -173,15 +172,14 @@ class AdminModeratorMixin(admin.ModelAdmin):
         """
         Add aditional moderate url.
         """
-        from django.conf.urls import patterns, url
+        from django.conf.urls import url
         urls = super(AdminModeratorMixin, self).get_urls()
         info = self.model._meta.app_label, self.model._meta.model_name
-        return patterns(
-            '',
+        return [
             url(r'^(.+)/moderate/$',
                 self.admin_site.admin_view(self.moderate_view),
                 name='%s_%s_moderate' % info),
-        ) + urls
+        ] + urls
 
     def moderate_view(self, request, object_id, extra_context=None):
         """

--- a/molo/commenting/tests/test_templatetags.py
+++ b/molo/commenting/tests/test_templatetags.py
@@ -1,3 +1,5 @@
+import re
+
 from datetime import datetime
 
 from django.contrib.auth.models import User
@@ -56,9 +58,15 @@ class GetMoloCommentsTest(TestCase, MoloTestCaseMixin):
         output = template.render(Context({
             'object': self.user,
         }))
+        expected_output = [
+            'comment 9\s+',
+            'comment 8\s+',
+            'comment 7\s+',
+            'comment 6\s+',
+            'comment 5\s+',
+        ]
+        self.assertNotEqual(re.search(''.join(expected_output), output), None)
         self.assertFalse('comment 4' in output)
-        self.assertTrue('comment 5' in output)
-        self.assertTrue('comment 9' in output)
 
     def test_template_tags_limits(self):
         template = Template("""
@@ -74,10 +82,12 @@ class GetMoloCommentsTest(TestCase, MoloTestCaseMixin):
         output = template.render(Context({
             'object': self.user,
         }))
-        self.assertFalse('comment 4' in output)
-        self.assertFalse('comment 5' in output)
-        self.assertTrue('comment 8' in output)
-        self.assertTrue('comment 9' in output)
+        expected_output = [
+            'comment 9\s+',
+            'comment 8\s+',
+        ]
+        self.assertNotEqual(re.search(''.join(expected_output), output), None)
+        self.assertFalse('comment 7' in output)
 
     def test_template_tags_unlimited(self):
         template = Template("""
@@ -93,8 +103,19 @@ class GetMoloCommentsTest(TestCase, MoloTestCaseMixin):
         output = template.render(Context({
             'object': self.user,
         }))
-        self.assertTrue('comment 1' in output)
-        self.assertTrue('comment 9' in output)
+        expected_output = [
+            'comment 9\s+',
+            'comment 8\s+',
+            'comment 7\s+',
+            'comment 6\s+',
+            'comment 5\s+',
+            'comment 4\s+',
+            'comment 3\s+',
+            'comment 2\s+',
+            'comment 1\s+',
+            'comment 0\s+',
+        ]
+        self.assertNotEqual(re.search(''.join(expected_output), output), None)
 
 
 class GetCommentsContentObjectTest(TestCase, MoloTestCaseMixin):

--- a/molo/commenting/tests/test_views.py
+++ b/molo/commenting/tests/test_views.py
@@ -1,7 +1,7 @@
 from bs4 import BeautifulSoup
 from datetime import datetime
 
-from django.conf.urls import patterns, url, include
+from django.conf.urls import url, include
 from django.core.urlresolvers import reverse
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
@@ -16,14 +16,13 @@ from molo.core.tests.base import MoloTestCaseMixin
 
 from notifications.models import Notification
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^commenting/',
         include('molo.commenting.urls', namespace='molo.commenting')),
     url(r'', include('django_comments.urls')),
     url(r'', include('molo.core.urls')),
     url(r'', include('wagtail.wagtailcore.urls')),
-)
+]
 
 
 @override_settings(ROOT_URLCONF='molo.commenting.tests.test_views')

--- a/molo/commenting/urls.py
+++ b/molo/commenting/urls.py
@@ -1,10 +1,9 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from molo.commenting import views
 from molo.commenting.views import CommentReplyView
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'molo/report/(\d+)/$', views.report, name='molo-comments-report'),
     url(r'^comments/reported/(?P<comment_pk>\d+)/$',
         views.report_response, name='report_response'),
@@ -20,4 +19,4 @@ urlpatterns = patterns(
         name='more-comments'),
     url(r'molo/replies/$',
         views.reply_list, name='reply_list'),
-)
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,6 @@
 exclude = ve,docs,molo/*/migrations/*
 ignore = F403
 
-[pytest]
+[tool:pytest]
 addopts = --doctest-modules --verbose --ds=testapp.settings --nomigrations --cov=molo --cov-report=term -s ./molo
 looponfailroots = molo


### PR DESCRIPTION
- Improve tests: these tests don't check the output order which I think is important
- Remove deprecated patterns()
- flake8 is installed twice
- twine isn't needed most of the time
- pytest gives a warning about the setup file