### PR TITLE
Set CommentData rule to be static

### DIFF
--- a/molo/commenting/rules.py
+++ b/molo/commenting/rules.py
@@ -8,6 +8,8 @@ from wagtail_personalisation.rules import AbstractBaseRule
 
 
 class CommentDataRule(AbstractBaseRule):
+    static = True
+
     EQUALS = 'eq'
     CONTAINS = 'in'
 

--- a/molo/commenting/tests/test_rules.py
+++ b/molo/commenting/tests/test_rules.py
@@ -41,6 +41,11 @@ class TestCommentDataRuleSegmentation(TestCase, MoloTestCaseMixin):
             parent=parent,
             submit_date=timezone.now())
 
+    def test_comment_data_rule_is_static(self):
+        rule = CommentDataRule(expected_content='that is some random content.',
+                               operator=CommentDataRule.EQUALS)
+        self.assertTrue(rule.static)
+
     def test_comment_data_exact_rule(self):
         self._create_comment('that is some random content.')
         rule = CommentDataRule(expected_content='that is some random content.',


### PR DESCRIPTION
The CommentData rule is supposed to be static but it seems that was missed.