### PR TITLE
Fix `format_html()` for parent comments containing unicode

### DIFF
--- a/molo/commenting/admin.py
+++ b/molo/commenting/admin.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
 from django_comments.models import CommentFlag
 from django_comments.admin import CommentsAdmin
 from django.contrib import admin

--- a/molo/commenting/tests/test_admin.py
+++ b/molo/commenting/tests/test_admin.py
@@ -56,6 +56,15 @@ class CommentingAdminTest(TestCase, MoloTestCaseMixin):
             '/admin/commenting/molocomment/?user__is_staff__exact=0')
         self.assertNotContains(response, 'staff user comment')
 
+    def test_parent_comment_can_contain_unicode(self):
+        comment_parent = self.mk_comment('Parent comment 👋')
+        comment_reply = self.mk_comment('Reply', parent=comment_parent)
+
+        response = self.client.get('/admin/commenting/molocomment/')
+
+        self.assertContains(response, comment_parent.comment)
+        self.assertContains(response, comment_reply.comment)
+
     def test_reply_link_on_comment(self):
         '''Every root comment should have the "Add reply" text and icon that
         has a link to the reply view for that comment.'''


### PR DESCRIPTION
This is required for Python 2 compatibility but can be removed when running on Python 3.