### PR TITLE
Remove `encode()` for article titles

### DIFF
--- a/molo/commenting/admin.py
+++ b/molo/commenting/admin.py
@@ -267,7 +267,7 @@ class MoloCommentsModelAdmin(WagtailModelAdmin, MoloCommentAdmin):
             return '<a href="{0}" target="_blank">{1}</a> ' \
                    '(<a href="/admin/pages/{2}/edit/">edit</a>)'\
                 .format(obj.content_object.url,
-                        obj.content_object.title.encode('utf-8'),
+                        obj.content_object.title,
                         obj.content_object.pk)
 
         return

--- a/molo/commenting/tests/test_admin.py
+++ b/molo/commenting/tests/test_admin.py
@@ -367,3 +367,19 @@ class TestMoloCommentsAdminViews(TestCase, MoloTestCaseMixin):
         )
 
         self.assertEquals(response.status_code, 302)
+
+    def test_article_title_in_comment_view_can_contain_unicode(self):
+        article = self.mk_article(self.yourmind, title='Test article 😴')
+        MoloComment.objects.create(
+            content_type=self.content_type,
+            object_pk=article.pk,
+            content_object=article,
+            site=Site.objects.first(),
+            user=self.user,
+            comment='Comment',
+            parent=None,
+            submit_date=timezone.now())
+
+        response = self.client.get('/admin/commenting/molocomment/')
+
+        self.assertContains(response, 'Test article 😴')


### PR DESCRIPTION
We don't need this anymore because everything here is a unicode literal.