### PR TITLE
Remove empty string from requirements list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,10 +7,10 @@ with open(os.path.join(here, 'README.rst')) as f:
     readme = f.read()
 
 with open(os.path.join(here, 'requirements.txt')) as f:
-    requires = f.read().split('\n')
+    requires = [req for req in f.read().split('\n') if req]
 
 with open(os.path.join(here, 'requirements-dev.txt')) as f:
-    requires_dev = f.read().split('\n')
+    requires_dev = [req for req in f.read().split('\n') if req]
 
 with open(os.path.join(here, 'VERSION')) as f:
     version = f.read().strip()


### PR DESCRIPTION
When we moved to Python 3 we used this simpler method to read the requirements file. However we need to remove the empty/Falsey elements from the list.

This fixes the error:

```
Failed building wheel for molo.commenting
```