### PR TITLE
Retrieve user info for CommentDataRule

### DIFF
--- a/molo/commenting/rules.py
+++ b/molo/commenting/rules.py
@@ -70,6 +70,6 @@ class CommentDataRule(AbstractBaseRule):
         matches = [comment.comment for comment in
                    comments.filter(**{'comment__i' + (
                                    'exact' if self.operator == self.EQUALS
-                                    else 'contains'): self.expected_content})]
+                                   else 'contains'): self.expected_content})]
 
-        return "\"%s\"" % ("\"\n\"".join(matches))  # Surround each comment in ""
+        return "\"%s\"" % ("\"\n\"".join(matches))  # Quote each comment

--- a/molo/commenting/rules.py
+++ b/molo/commenting/rules.py
@@ -61,3 +61,15 @@ class CommentDataRule(AbstractBaseRule):
                 Truncator(self.expected_content).chars(20)
             )
         }
+
+    def get_column_header(self):
+        return "Comment Data"
+
+    def get_user_info_string(self, user):
+        comments = user.comment_comments
+        matches = [comment.comment for comment in
+                   comments.filter(**{'comment__i' + (
+                                   'exact' if self.operator == self.EQUALS
+                                    else 'contains'): self.expected_content})]
+
+        return "\"%s\"" % ("\"\n\"".join(matches))  # Surround each comment in ""

--- a/molo/commenting/tests/test_rules.py
+++ b/molo/commenting/tests/test_rules.py
@@ -86,3 +86,34 @@ class TestCommentDataRuleSegmentation(TestCase, MoloTestCaseMixin):
         rule = CommentDataRule(expected_content='that is some random content.',
                                operator=CommentDataRule.EQUALS)
         self.assertFalse(rule.test_user(None))
+
+    def test_get_column_header(self):
+        rule = CommentDataRule(expected_content='that is some random content.',
+                               operator=CommentDataRule.EQUALS)
+        self.assertEqual(rule.get_column_header(), "Comment Data")
+
+    def test_get_user_data_string_returns_data_for_exact_match(self):
+        self._create_comment('that is some random content.')
+        rule = CommentDataRule(expected_content='that is some random content.',
+                               operator=CommentDataRule.EQUALS)
+
+        self.assertEqual(rule.get_user_info_string(self.request.user),
+                         '"that is some random content."')
+
+    def test_get_user_data_string_returns_data_for_contains(self):
+        self._create_comment('that is some random content.')
+        rule = CommentDataRule(expected_content='some random',
+                               operator=CommentDataRule.CONTAINS)
+
+        self.assertEqual(rule.get_user_info_string(self.request.user),
+                         '"that is some random content."')
+
+    def test_get_user_data_string_concatenates_multiple_matches(self):
+        self._create_comment('that is some random content.')
+        self._create_comment('that is some other content.')
+        rule = CommentDataRule(expected_content='that is some',
+                               operator=CommentDataRule.CONTAINS)
+
+        self.assertEqual(rule.get_user_info_string(self.request.user),
+                         '"that is some random content."\n'
+                         '"that is some other content."')


### PR DESCRIPTION
In order to show how a user matched the rules of a segment we need to get the user's data for each rule. Only the rule knows which field must be retrieved and what it should be called.
These methods will be called when compiling a csv of the users that matched a static segments rules.

This adds methods for getting that data to the Comment Data segmentation rules.