### PR TITLE
Return useful message if user doesn't match comment data rule

### DIFF
--- a/molo/commenting/rules.py
+++ b/molo/commenting/rules.py
@@ -72,4 +72,6 @@ class CommentDataRule(AbstractBaseRule):
                                    'exact' if self.operator == self.EQUALS
                                    else 'contains'): self.expected_content})]
 
+        if not matches:
+            return "No matching comments"
         return "\"%s\"" % ("\"\n\"".join(matches))  # Quote each comment

--- a/molo/commenting/tests/test_rules.py
+++ b/molo/commenting/tests/test_rules.py
@@ -117,3 +117,12 @@ class TestCommentDataRuleSegmentation(TestCase, MoloTestCaseMixin):
         self.assertEqual(rule.get_user_info_string(self.request.user),
                          '"that is some random content."\n'
                          '"that is some other content."')
+
+    def test_get_user_data_string_returns_if_no_matches(self):
+        self._create_comment('that is some random content.')
+        self._create_comment('that is some other content.')
+        rule = CommentDataRule(expected_content='bla bla bla',
+                               operator=CommentDataRule.CONTAINS)
+
+        self.assertEqual(rule.get_user_info_string(self.request.user),
+                         'No matching comments')


### PR DESCRIPTION
This ensures we get a meaningful response from `get_user_info_string` when the user doesn't have any comments that match the rule.