### PR TITLE
Check for NoneType content_object when exporting country

### DIFF
--- a/molo/commenting/admin_import_export.py
+++ b/molo/commenting/admin_import_export.py
@@ -25,7 +25,13 @@ class MoloCommentsResource(resources.ModelResource):
             'article_full_url', 'is_public', 'is_removed')
 
     def dehydrate_country(self, comment):
-        return comment.content_object.get_site().root_page.title
+        dehydrated_country = ''
+
+        if comment.content_object:
+            site = comment.content_object.get_site()
+            dehydrated_country = site.root_page.title
+
+        return dehydrated_country
 
     def dehydrate_article_title(self, comment):
         if not comment.content_object or not \


### PR DESCRIPTION
This conditional was removed in e496a30604952391e5ecc3cb17eb8f1f37e3c443 but I'm not sure why.

I can't write a test for this because I can't figure out how to create/save a comment with a content_object of None/False.