### PR TITLE
Fix admin pagination when filtering on date

### DIFF
--- a/molo/commenting/admin_views.py
+++ b/molo/commenting/admin_views.py
@@ -44,6 +44,13 @@ class MoloCommentsAdminView(IndexView):
             "CSV emailed to '{0}'").format(request.user.email))
         return redirect(request.path)
 
+    def get_query_string(self, new_params=None, remove=None):
+        # For some reason the date filters get removed from the parameters
+        # Add them back but update anything that might need to change.
+        params = dict(self.request.GET.items())
+        params.update(new_params)
+        return super().get_query_string(new_params=params, remove=remove)
+
     def get_template_names(self):
         return 'admin/molo_comments_admin.html'
 

--- a/molo/commenting/tests/test_admin.py
+++ b/molo/commenting/tests/test_admin.py
@@ -56,6 +56,18 @@ class CommentingAdminTest(TestCase, MoloTestCaseMixin):
             '/admin/commenting/molocomment/?user__is_staff__exact=0')
         self.assertNotContains(response, 'staff user comment')
 
+    def test_pagination_link_keeps_date_filter(self):
+        i = 0
+        while i < 102:
+            self.mk_comment(comment=i)
+            i += 1
+
+        date = timezone.now().strftime("%Y-%m-%d")
+        response = self.client.get(
+            '/admin/commenting/molocomment/?drf__submit_date__gte=%s' % date)
+        self.assertContains(
+            response, 'href="?drf__submit_date__gte=%s&p=1"' % date)
+
     def test_parent_comment_can_contain_unicode(self):
         comment_parent = self.mk_comment('Parent comment 👋')
         comment_reply = self.mk_comment('Reply', parent=comment_parent)


### PR DESCRIPTION
When filtering comments by date in the admin, the "next" and "previous" links don't have the filter parameters. So clicking them clears the filter. This doesn't happen with other filters, only the date one.

Somewhere in the view the filter params for the date filter are being lost. I haven't figured out where they are being removed but the get_query_string method is where we need them when we generate the "next" link for the pagination. So we overwrite that to get the old params and then update that with the new params (page number ect)