### PR TITLE
Loosen personalisation dep so molo.forms can dictate version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ molo.core>=11.0.5,<12.0.0
 django-contrib-comments==2.0.0
 django-import-export
 django-notifications-hq
-wagtail-personalisation-molo==3.0.3
+wagtail-personalisation-molo>=3.0.4,<4.0.0
 Unidecode==0.04.16
 django-admin-rangefilter==0.8.1


### PR DESCRIPTION
I loosened the version requirements because I feel like molo.forms should dictate the version number